### PR TITLE
Fix typo in k8s appliances README

### DIFF
--- a/appliances/kubernetes/README.md
+++ b/appliances/kubernetes/README.md
@@ -23,7 +23,7 @@ appropriate IP addresses).
 ETCD_IPS=1.2.3.4,2.3.4.5 ./master.sh
 ```
 
-To run the master, create two environment variables. One is ETCD_IPS (as above),
+To run the worker, create two environment variables. One is ETCD_IPS (as above),
 while the other is MASTER_IP for the master's IP address. Then run something like
 the following (with the appropriate IP addresses):
 


### PR DESCRIPTION
Last section of the k8s appliance README is about worker nodes.
Fixed the typo master->worker to adjust as it should be. 